### PR TITLE
Optimize memory usage for Railway deployment

### DIFF
--- a/RAILWAY_DEPLOYMENT.md
+++ b/RAILWAY_DEPLOYMENT.md
@@ -148,6 +148,55 @@ Para actualizar la aplicación:
 2. Railway detectará automáticamente los cambios y desplegará una nueva versión
 3. Puedes configurar "Auto Deploy" en Settings para desplegar automáticamente en cada push
 
+## Optimización de Memoria (1GB RAM)
+
+La aplicación está optimizada para funcionar eficientemente con el límite de 1GB de RAM en Railway. Las siguientes optimizaciones están implementadas:
+
+### Optimizaciones JVM
+
+- **Heap máximo**: 512MB (`-Xmx512m`)
+- **Heap inicial**: 256MB (`-Xms256m`)
+- **Metaspace máximo**: 128MB (metadatos de clases)
+- **Code cache**: 64MB
+- **Garbage Collector**: G1GC (optimizado para bajos recursos)
+- **Compresión de punteros**: Habilitada para reducir uso de memoria
+- **Deduplicación de strings**: Automática para ahorrar memoria
+
+### Optimizaciones de Base de Datos
+
+- **Pool de conexiones reducido**: Máximo 5 conexiones (antes 10)
+- **Conexiones idle mínimas**: 2 (antes 5)
+- **Batch processing**: Habilitado para operaciones en lote
+- **Cache de segundo nivel**: Deshabilitado (ahorra memoria significativa)
+- **Open-in-View**: Deshabilitado (mejora el rendimiento y reduce memoria)
+
+### Optimizaciones de Spring Boot
+
+- **JMX**: Deshabilitado
+- **Background pre-initialization**: Deshabilitado
+- **Actuator**: Solo endpoint de health (métricas deshabilitadas)
+- **Logging**: Reducido a niveles esenciales (WARN/ERROR para frameworks)
+- **File logging**: Deshabilitado en producción
+
+### Monitoreo de Memoria
+
+Para monitorear el uso de memoria en Railway:
+
+1. Ve a la pestaña "Metrics" en tu servicio
+2. Revisa el uso de memoria en tiempo real
+3. Si ves picos cercanos a 1GB, considera:
+   - Reducir aún más el pool de conexiones
+   - Revisar consultas que carguen muchos datos
+   - Implementar paginación en endpoints que devuelvan listas grandes
+
+### Ajustes Adicionales (si es necesario)
+
+Si después del despliegue observas problemas de memoria, puedes ajustar en `docker-entrypoint.sh`:
+
+- Reducir `-Xmx512m` a `-Xmx384m` (dejar más espacio para no-heap)
+- Reducir `spring.datasource.hikari.maximum-pool-size` a 3
+- Aumentar `-XX:MaxGCPauseMillis` a 300 si hay pausas frecuentes
+
 ## Costos
 
 - **Plan Hobby**: $5/mes (incluye $5 de crédito)

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,13 +8,29 @@ PORT=${PORT:-8080}
 # Export PORT so Spring Boot can use it
 export PORT
 
-# Set server.port system property explicitly for Spring Boot
-# This ensures the application binds to Railway's assigned port
-JAVA_OPTS="-Dserver.port=${PORT}"
+# Memory optimization for 1GB RAM limit
+# -Xmx512m: Maximum heap size (512MB, leaving ~500MB for non-heap, OS, and buffer)
+# -Xms256m: Initial heap size (256MB, reduces GC overhead)
+# -XX:+UseG1GC: Use G1 garbage collector (efficient for low memory)
+# -XX:MaxGCPauseMillis=200: Target max GC pause time
+# -XX:+UseStringDeduplication: Deduplicate strings to save memory
+# -XX:+OptimizeStringConcat: Optimize string concatenation
+# -XX:+UseCompressedOops: Use compressed object pointers (saves memory on 64-bit)
+# -XX:+UseCompressedClassPointers: Compress class pointers
+# -XX:MaxMetaspaceSize=128m: Limit metaspace (class metadata)
+# -XX:ReservedCodeCacheSize=64m: Limit code cache
+# -XX:+ExitOnOutOfMemoryError: Exit if OOM (better than hanging)
+# -XX:+HeapDumpOnOutOfMemoryError: Generate heap dump on OOM for debugging
+# -XX:HeapDumpPath=/tmp: Where to save heap dumps
+# -Djava.security.egd=file:/dev/./urandom: Faster startup (non-blocking random)
+# -Dspring.jmx.enabled=false: Disable JMX (saves memory)
+# -Dspring.backgroundpreinitializer.ignore=true: Disable background pre-initialization
+JAVA_OPTS="-Xmx512m -Xms256m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseStringDeduplication -XX:+OptimizeStringConcat -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:MaxMetaspaceSize=128m -XX:ReservedCodeCacheSize=64m -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Djava.security.egd=file:/dev/./urandom -Dspring.jmx.enabled=false -Dspring.backgroundpreinitializer.ignore=true -Dserver.port=${PORT}"
 
-# Log the port being used (helpful for debugging)
+# Log the port and memory settings (helpful for debugging)
 echo "Starting application on port: ${PORT}"
+echo "JVM Memory settings: Max Heap=512MB, Initial Heap=256MB, Max Metaspace=128MB"
 
-# Run the Spring Boot application with dynamic port configuration
+# Run the Spring Boot application with dynamic port configuration and memory optimization
 exec java ${JAVA_OPTS} -jar app.jar
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -13,18 +13,32 @@ spring.datasource.username=${MYSQL_USER}
 spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-# JPA/Hibernate Configuration
+# JPA/Hibernate Configuration (Optimized for memory)
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=false
+# Memory optimizations
+spring.jpa.properties.hibernate.jdbc.batch_size=20
+spring.jpa.properties.hibernate.order_inserts=true
+spring.jpa.properties.hibernate.order_updates=true
+spring.jpa.properties.hibernate.jdbc.batch_versioned_data=true
+# Disable second-level cache (saves memory, use Redis if needed)
+spring.jpa.properties.hibernate.cache.use_second_level_cache=false
+spring.jpa.properties.hibernate.cache.use_query_cache=false
+# Optimize session management
+spring.jpa.properties.hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS=0
+spring.jpa.open-in-view=false
 
-# Connection Pool Configuration
-spring.datasource.hikari.maximum-pool-size=10
-spring.datasource.hikari.minimum-idle=5
+# Connection Pool Configuration (Optimized for 1GB RAM)
+# Reduced pool size to save memory - each connection uses ~1-2MB
+spring.datasource.hikari.maximum-pool-size=5
+spring.datasource.hikari.minimum-idle=2
 spring.datasource.hikari.idle-timeout=300000
 spring.datasource.hikari.connection-timeout=20000
 spring.datasource.hikari.leak-detection-threshold=60000
+spring.datasource.hikari.max-lifetime=600000
+spring.datasource.hikari.connection-test-query=SELECT 1
 
 # Flyway Configuration
 spring.flyway.enabled=true
@@ -47,19 +61,32 @@ spring.web.cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS,PATCH
 spring.web.cors.allowed-headers=*
 spring.web.cors.allow-credentials=true
 
-# Logging Configuration
-logging.level.root=INFO
+# Logging Configuration (Optimized for memory)
+# Reduced logging to save memory - only essential logs
+logging.level.root=WARN
 logging.level.com.univercloud.hydro=INFO
-logging.level.org.springframework.security=WARN
-logging.level.org.springframework.web=INFO
-logging.level.org.hibernate=WARN
-logging.pattern.console=%d{yyyy-MM-dd HH:mm:ss} - %msg%n
-logging.pattern.file=%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+logging.level.org.springframework.security=ERROR
+logging.level.org.springframework.web=WARN
+logging.level.org.hibernate=ERROR
+logging.level.org.springframework.boot=WARN
+logging.level.org.apache.tomcat=WARN
+# Simple logging pattern to reduce memory usage
+logging.pattern.console=%d{HH:mm:ss} %-5level %msg%n
+# Disable file logging in production (saves memory and disk I/O)
+logging.file.name=
+# Limit log buffer size
+logging.pattern.rolling-file-name=
 
-# Actuator Configuration (for health checks)
-management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=when-authorized
+# Actuator Configuration (for health checks - minimal for memory savings)
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
 management.health.db.enabled=true
+# Disable unnecessary actuator features
+management.metrics.export.enabled=false
+management.endpoint.metrics.enabled=false
+management.endpoint.prometheus.enabled=false
+# Disable DevTools in production (if present)
+spring.devtools.restart.enabled=false
 
 # Error Handling
 server.error.include-message=always


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tune JVM, Spring Boot, and DB settings for 1GB Railway deployments and document memory optimizations.
> 
> - **Backend configuration**:
>   - **JVM (docker-entrypoint.sh)**: Add memory-tuned flags (`-Xmx512m`, `-Xms256m`, G1GC, metaspace/code cache limits, string dedup, compressed pointers) and startup logs; bind `server.port` via `JAVA_OPTS`.
>   - **Spring Boot prod properties (`application-prod.properties`)**:
>     - JPA/Hibernate: enable batching/order, disable second-level/query cache, turn off open-in-view.
>     - Hikari: reduce pool size to `max=5`/`minIdle=2`, add `max-lifetime`, `connection-test-query`, keep conservative timeouts.
>     - Logging: lower verbosity (root WARN, key frameworks WARN/ERROR), simplify console pattern, disable file logging.
>     - Actuator/Metrics: expose only `health`, hide details, disable metrics/prometheus; disable DevTools.
> - **Documentation**:
>   - `RAILWAY_DEPLOYMENT.md`: Add detailed "Optimización de Memoria (1GB RAM)" with JVM, DB, Spring tweaks, monitoring guidance, and adjustable parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27b4966fc044bd04d21e1c49f425f6012d0f3ef2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->