### PR TITLE
Update EntityGraph annotations in MonitoringStationRepository to incl…

### DIFF
--- a/src/main/java/com/univercloud/hydro/repository/MonitoringStationRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/MonitoringStationRepository.java
@@ -22,26 +22,30 @@ public interface MonitoringStationRepository extends JpaRepository<MonitoringSta
     
     /**
      * Busca estaciones por corporación.
+     * Carga la relación waterBasin para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @return lista de estaciones de la corporación
      */
-    @EntityGraph(attributePaths = {"basinSection"})
+    @EntityGraph(attributePaths = {"basinSection.waterBasin"})
     List<MonitoringStation> findByCorporation(Corporation corporation);
     
     /**
      * Busca estaciones por corporación con paginación.
+     * Carga la relación waterBasin para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @param pageable parámetros de paginación
      * @return página de estaciones de la corporación
      */
-    @EntityGraph(attributePaths = {"basinSection"})
+    @EntityGraph(attributePaths = {"basinSection.waterBasin"})
     Page<MonitoringStation> findByCorporation(Corporation corporation, Pageable pageable);
     
     /**
      * Busca estaciones activas por corporación.
+     * Carga la relación waterBasin para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @return lista de estaciones activas de la corporación
      */
+    @EntityGraph(attributePaths = {"basinSection.waterBasin"})
     List<MonitoringStation> findByCorporationAndIsActiveTrue(Corporation corporation);
     
     /**


### PR DESCRIPTION
…ude waterBasin relationship, optimizing lazy loading for related entities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands EntityGraph on MonitoringStationRepository queries to load `basinSection.waterBasin`, reducing lazy-loading issues.
> 
> - **Repository** (`src/main/java/com/univercloud/hydro/repository/MonitoringStationRepository.java`):
>   - Update `@EntityGraph` from `"basinSection"` to `"basinSection.waterBasin"` for `findByCorporation(Corporation)` and `findByCorporation(Corporation, Pageable)`.
>   - Add `@EntityGraph(attributePaths = {"basinSection.waterBasin"})` to `findByCorporationAndIsActiveTrue(Corporation)`.
>   - Update Javadoc to note loading of `waterBasin` to avoid lazy-loading issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e73bd2dafd3dd7b6c4ad7054f742c0483689eda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->