### PR TITLE
Enhance EntityGraph annotations in DischargeRepository to include dis…

### DIFF
--- a/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
@@ -23,17 +23,21 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por usuario de descarga.
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param dischargeUser el usuario de descarga
      * @return lista de descargas del usuario
      */
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     List<Discharge> findByDischargeUser(DischargeUser dischargeUser);
     
     /**
      * Busca una descarga por número y año.
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param number el número de descarga
      * @param year el año
      * @return la descarga si existe
      */
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     Optional<Discharge> findByNumberAndYear(Integer number, Integer year);
     
     /**
@@ -59,37 +63,43 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por corporación y nombre (búsqueda parcial, case-insensitive).
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @param name el nombre o parte del nombre a buscar
      * @return lista de descargas de la corporación que coinciden con el nombre
      */
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     @Query("SELECT d FROM Discharge d WHERE d.corporation = :corporation AND LOWER(d.name) LIKE LOWER(CONCAT('%', :name, '%'))")
     List<Discharge> findByCorporationAndNameContainingIgnoreCase(@Param("corporation") Corporation corporation, @Param("name") String name);
     
     /**
      * Busca descargas por corporación con paginación.
-     * Carga la relación dischargeUser con las relaciones municipality.department, municipality.category, economicActivity y authorizationType para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @param pageable parámetros de paginación
      * @return página de descargas de la corporación
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin"})
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     Page<Discharge> findByCorporation(Corporation corporation, Pageable pageable);
     
     /**
      * Busca descargas por corporación y año.
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @param year el año
      * @return lista de descargas de la corporación y año
      */
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     List<Discharge> findByCorporationAndYear(Corporation corporation, Integer year);
     
     /**
      * Busca una descarga por ID y corporación.
+     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
      * @param id el ID de la descarga
      * @param corporationId el ID de la corporación
      * @return la descarga si existe y pertenece a la corporación
      */
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     @Query("SELECT d FROM Discharge d WHERE d.id = :id AND d.corporation.id = :corporationId")
     Optional<Discharge> findByIdAndCorporationId(@Param("id") Long id, @Param("corporationId") Long corporationId);
 }


### PR DESCRIPTION
…chargeParameters, improving lazy loading of related entities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend EntityGraphs in `DischargeRepository` to eagerly load `dischargeParameters` across key queries.
> 
> - **Repository (`DischargeRepository`)**:
>   - Extend `@EntityGraph` across queries to also load `dischargeParameters` alongside existing relations.
>     - Affected methods: `findByDischargeUser`, `findByNumberAndYear`, `findByCorporationAndNameContainingIgnoreCase`, `findByCorporation` (paged), `findByCorporationAndYear`, `findByIdAndCorporationId`.
>   - Update Javadoc to note eager loading of `dischargeParameters`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4392f07f4fb90d907ab0096b225613f43ee6e3b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->