### PR TITLE
Refactor DischargeController, DischargeService, and DischargeReposito…

### DIFF
--- a/src/main/java/com/univercloud/hydro/controller/DischargeController.java
+++ b/src/main/java/com/univercloud/hydro/controller/DischargeController.java
@@ -1,5 +1,6 @@
 package com.univercloud.hydro.controller;
 
+import com.univercloud.hydro.dto.DischargeDto;
 import com.univercloud.hydro.entity.Discharge;
 import com.univercloud.hydro.service.DischargeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -84,13 +85,13 @@ public class DischargeController {
      * Obtiene todas las descargas de la corporación del usuario autenticado con paginación.
      * 
      * @param pageable parámetros de paginación
-     * @return página de descargas
+     * @return página de descargas como DTOs
      */
     @GetMapping
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Page<Discharge>> getMyCorporationDischarges(Pageable pageable) {
+    public ResponseEntity<Page<DischargeDto>> getMyCorporationDischarges(Pageable pageable) {
         try {
-            Page<Discharge> discharges = dischargeService.getMyCorporationDischarges(pageable);
+            Page<DischargeDto> discharges = dischargeService.getMyCorporationDischarges(pageable);
             return ResponseEntity.ok(discharges);
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
@@ -101,13 +102,13 @@ public class DischargeController {
      * Obtiene descargas por usuario de descarga.
      * 
      * @param dischargeUserId el ID del usuario de descarga
-     * @return lista de descargas del usuario
+     * @return lista de descargas del usuario como DTOs
      */
     @GetMapping("/by-discharge-user/{dischargeUserId}")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<List<Discharge>> getDischargesByDischargeUser(@PathVariable Long dischargeUserId) {
+    public ResponseEntity<List<DischargeDto>> getDischargesByDischargeUser(@PathVariable Long dischargeUserId) {
         try {
-            List<Discharge> discharges = dischargeService.getDischargesByDischargeUser(dischargeUserId);
+            List<DischargeDto> discharges = dischargeService.getDischargesByDischargeUser(dischargeUserId);
             return ResponseEntity.ok(discharges);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().build();

--- a/src/main/java/com/univercloud/hydro/dto/DischargeDto.java
+++ b/src/main/java/com/univercloud/hydro/dto/DischargeDto.java
@@ -1,0 +1,99 @@
+package com.univercloud.hydro.dto;
+
+import com.univercloud.hydro.entity.Discharge;
+import java.math.BigDecimal;
+
+/**
+ * DTO simplificado para listado de descargas.
+ * Contiene solo los campos esenciales para la visualización en listados.
+ */
+public class DischargeDto {
+    
+    private Long id;
+    private String name;
+    private Integer number;
+    private Integer year;
+    private String dischargePoint;
+    private BigDecimal ccDboTotal;
+    private BigDecimal ccSstTotal;
+    private String companyName;
+    
+    // Constructors
+    public DischargeDto() {}
+    
+    public DischargeDto(Discharge discharge) {
+        this.id = discharge.getId();
+        this.name = discharge.getName();
+        this.number = discharge.getNumber();
+        this.year = discharge.getYear();
+        this.dischargePoint = discharge.getDischargePoint();
+        this.ccDboTotal = discharge.getCcDboTotal();
+        this.ccSstTotal = discharge.getCcSstTotal();
+        this.companyName = discharge.getDischargeUser() != null ? discharge.getDischargeUser().getCompanyName() : null;
+    }
+    
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+    
+    public void setId(Long id) {
+        this.id = id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public Integer getNumber() {
+        return number;
+    }
+    
+    public void setNumber(Integer number) {
+        this.number = number;
+    }
+    
+    public Integer getYear() {
+        return year;
+    }
+    
+    public void setYear(Integer year) {
+        this.year = year;
+    }
+    
+    public String getDischargePoint() {
+        return dischargePoint;
+    }
+    
+    public void setDischargePoint(String dischargePoint) {
+        this.dischargePoint = dischargePoint;
+    }
+    
+    public BigDecimal getCcDboTotal() {
+        return ccDboTotal;
+    }
+    
+    public void setCcDboTotal(BigDecimal ccDboTotal) {
+        this.ccDboTotal = ccDboTotal;
+    }
+    
+    public BigDecimal getCcSstTotal() {
+        return ccSstTotal;
+    }
+    
+    public void setCcSstTotal(BigDecimal ccSstTotal) {
+        this.ccSstTotal = ccSstTotal;
+    }
+    
+    public String getCompanyName() {
+        return companyName;
+    }
+    
+    public void setCompanyName(String companyName) {
+        this.companyName = companyName;
+    }
+}

--- a/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
@@ -27,7 +27,7 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
      * @param dischargeUser el usuario de descarga
      * @return lista de descargas del usuario
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser"})
     List<Discharge> findByDischargeUser(DischargeUser dischargeUser);
     
     /**
@@ -79,7 +79,7 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
      * @param pageable parámetros de paginación
      * @return página de descargas de la corporación
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser"})
     Page<Discharge> findByCorporation(Corporation corporation, Pageable pageable);
     
     /**

--- a/src/main/java/com/univercloud/hydro/service/DischargeService.java
+++ b/src/main/java/com/univercloud/hydro/service/DischargeService.java
@@ -1,5 +1,6 @@
 package com.univercloud.hydro.service;
 
+import com.univercloud.hydro.dto.DischargeDto;
 import com.univercloud.hydro.entity.Discharge;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -39,16 +40,16 @@ public interface DischargeService {
     /**
      * Obtiene todas las descargas de la corporación del usuario autenticado.
      * @param pageable parámetros de paginación
-     * @return página de descargas
+     * @return página de descargas como DTOs
      */
-    Page<Discharge> getMyCorporationDischarges(Pageable pageable);
+    Page<DischargeDto> getMyCorporationDischarges(Pageable pageable);
     
     /**
      * Obtiene descargas por usuario de descarga.
      * @param dischargeUserId el ID del usuario de descarga
-     * @return lista de descargas del usuario
+     * @return lista de descargas del usuario como DTOs
      */
-    List<Discharge> getDischargesByDischargeUser(Long dischargeUserId);
+    List<DischargeDto> getDischargesByDischargeUser(Long dischargeUserId);
     
     /**
      * Obtiene descargas por año.


### PR DESCRIPTION
…ry to use DischargeDto for improved data transfer. Update methods to return DTOs instead of entities, enhancing API response structure and clarity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to API contract changes (list endpoints now return DTOs instead of entities) and modified JPA `@EntityGraph` fetch plans, which could affect clients and lazy-loading/performance behavior.
> 
> **Overview**
> **Discharge listing APIs now return DTOs instead of entities.** `GET /api/discharges` and `GET /api/discharges/by-discharge-user/{id}` were refactored across controller/service layers to return `DischargeDto` (new class with a reduced field set plus `companyName`) and the service now maps `Discharge` results into DTOs (including wrapping pages via `PageImpl`).
> 
> Repository fetch strategy for these list queries was tightened by reducing `@EntityGraph` on `findByCorporation` and `findByDischargeUser` to only eager-load `dischargeUser`. Unit tests were updated to assert DTO mapping and to cover the new `getDischargesByDischargeUser` behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ed7944f083a94f51cf2779bcbf16caca2c4f075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->