### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/univercloud/hydro/controller/DischargeController.java
+++ b/src/main/java/com/univercloud/hydro/controller/DischargeController.java
@@ -118,48 +118,16 @@ public class DischargeController {
     }
     
     /**
-     * Obtiene descargas por año.
-     * 
-     * @param year el año
-     * @return lista de descargas del año
-     */
-    @GetMapping("/by-year/{year}")
-    @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<List<Discharge>> getDischargesByYear(@PathVariable Integer year) {
-        try {
-            List<Discharge> discharges = dischargeService.getDischargesByYear(year);
-            return ResponseEntity.ok(discharges);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-    }
-        
-    /**
-     * Busca una descarga por número y año.
-     * 
-     * @param number el número de descarga
-     * @param year el año
-     * @return la descarga si existe
-     */
-    @GetMapping("/by-number-year")
-    @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<Discharge> getDischargeByNumberAndYear(@RequestParam Integer number, @RequestParam Integer year) {
-        Optional<Discharge> discharge = dischargeService.getDischargeByNumberAndYear(number, year);
-        return discharge.map(ResponseEntity::ok)
-                      .orElse(ResponseEntity.notFound().build());
-    }
-    
-    /**
      * Busca descargas por nombre (búsqueda parcial).
      * 
      * @param name el nombre o parte del nombre a buscar
-     * @return lista de descargas que coinciden
+     * @return lista de descargas que coinciden como DTOs
      */
     @GetMapping("/search")
     @PreAuthorize("hasRole('USER')")
-    public ResponseEntity<List<Discharge>> searchDischargesByName(@RequestParam String name) {
+    public ResponseEntity<List<DischargeDto>> searchDischargesByName(@RequestParam String name) {
         try {
-            List<Discharge> discharges = dischargeService.searchDischargesByName(name);
+            List<DischargeDto> discharges = dischargeService.searchDischargesByName(name);
             return ResponseEntity.ok(discharges);
         } catch (IllegalStateException e) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();

--- a/src/main/java/com/univercloud/hydro/repository/DischargeMonitoringRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeMonitoringRepository.java
@@ -194,13 +194,4 @@ public interface DischargeMonitoringRepository extends JpaRepository<DischargeMo
     @Query("SELECT dm FROM DischargeMonitoring dm WHERE dm.id = :id AND dm.corporation.id = :corporationId")
     Optional<DischargeMonitoring> findByIdAndCorporationId(@Param("id") Long id, @Param("corporationId") Long corporationId);
     
-    /**
-     * Busca monitoreos por múltiples IDs de descarga en una sola consulta.
-     * Este método se usa para evitar el problema N+1 al cargar monitorings para múltiples descargas.
-     * @param dischargeIds lista de IDs de descarga
-     * @return lista de monitoreos agrupados por descarga
-     */
-    @Query("SELECT dm FROM DischargeMonitoring dm WHERE dm.discharge.id IN :dischargeIds")
-    List<DischargeMonitoring> findByDischargeIdIn(@Param("dischargeIds") List<Long> dischargeIds);
-    
 }

--- a/src/main/java/com/univercloud/hydro/repository/DischargeMonitoringRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeMonitoringRepository.java
@@ -194,4 +194,13 @@ public interface DischargeMonitoringRepository extends JpaRepository<DischargeMo
     @Query("SELECT dm FROM DischargeMonitoring dm WHERE dm.id = :id AND dm.corporation.id = :corporationId")
     Optional<DischargeMonitoring> findByIdAndCorporationId(@Param("id") Long id, @Param("corporationId") Long corporationId);
     
+    /**
+     * Busca monitoreos por múltiples IDs de descarga en una sola consulta.
+     * Este método se usa para evitar el problema N+1 al cargar monitorings para múltiples descargas.
+     * @param dischargeIds lista de IDs de descarga
+     * @return lista de monitoreos agrupados por descarga
+     */
+    @Query("SELECT dm FROM DischargeMonitoring dm WHERE dm.discharge.id IN :dischargeIds")
+    List<DischargeMonitoring> findByDischargeIdIn(@Param("dischargeIds") List<Long> dischargeIds);
+    
 }

--- a/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
@@ -23,7 +23,7 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por usuario de descarga.
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias incluyendo dischargeUser para evitar problemas de lazy loading.
      * @param dischargeUser el usuario de descarga
      * @return lista de descargas del usuario
      */
@@ -74,7 +74,7 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por corporación con paginación.
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias incluyendo dischargeUser para evitar problemas de lazy loading.
      * @param corporation la corporación
      * @param pageable parámetros de paginación
      * @return página de descargas de la corporación

--- a/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
@@ -31,16 +31,6 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     List<Discharge> findByDischargeUser(DischargeUser dischargeUser);
     
     /**
-     * Busca una descarga por número y año.
-     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
-     * @param number el número de descarga
-     * @param year el año
-     * @return la descarga si existe
-     */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
-    Optional<Discharge> findByNumberAndYear(Integer number, Integer year);
-    
-    /**
      * Verifica si existe una descarga con el número y año especificados en la corporación.
      * @param corporation la corporación
      * @param number el número de descarga
@@ -81,16 +71,6 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
      */
     @EntityGraph(attributePaths = {"dischargeUser"})
     Page<Discharge> findByCorporation(Corporation corporation, Pageable pageable);
-    
-    /**
-     * Busca descargas por corporación y año.
-     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
-     * @param corporation la corporación
-     * @param year el año
-     * @return lista de descargas de la corporación y año
-     */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
-    List<Discharge> findByCorporationAndYear(Corporation corporation, Integer year);
     
     /**
      * Busca una descarga por ID y corporación.

--- a/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
+++ b/src/main/java/com/univercloud/hydro/repository/DischargeRepository.java
@@ -32,12 +32,12 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca una descarga por número y año.
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
      * @param number el número de descarga
      * @param year el año
      * @return la descarga si existe
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     Optional<Discharge> findByNumberAndYear(Integer number, Integer year);
     
     /**
@@ -63,12 +63,12 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por corporación y nombre (búsqueda parcial, case-insensitive).
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
      * @param corporation la corporación
      * @param name el nombre o parte del nombre a buscar
      * @return lista de descargas de la corporación que coinciden con el nombre
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     @Query("SELECT d FROM Discharge d WHERE d.corporation = :corporation AND LOWER(d.name) LIKE LOWER(CONCAT('%', :name, '%'))")
     List<Discharge> findByCorporationAndNameContainingIgnoreCase(@Param("corporation") Corporation corporation, @Param("name") String name);
     
@@ -84,22 +84,23 @@ public interface DischargeRepository extends JpaRepository<Discharge, Long> {
     
     /**
      * Busca descargas por corporación y año.
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
      * @param corporation la corporación
      * @param year el año
      * @return lista de descargas de la corporación y año
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     List<Discharge> findByCorporationAndYear(Corporation corporation, Integer year);
     
     /**
      * Busca una descarga por ID y corporación.
-     * Carga las relaciones necesarias incluyendo dischargeParameters para evitar problemas de lazy loading.
+     * Carga las relaciones necesarias. Solo carga dischargeParameters para evitar MultipleBagFetchException.
+     * dischargeMonitorings se carga manualmente en el servicio si es necesario.
      * @param id el ID de la descarga
      * @param corporationId el ID de la corporación
      * @return la descarga si existe y pertenece a la corporación
      */
-    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters", "dischargeMonitorings"})
+    @EntityGraph(attributePaths = {"dischargeUser.municipality.department", "dischargeUser.municipality.category", "dischargeUser.economicActivity", "dischargeUser.authorizationType", "basinSection.waterBasin", "dischargeParameters"})
     @Query("SELECT d FROM Discharge d WHERE d.id = :id AND d.corporation.id = :corporationId")
     Optional<Discharge> findByIdAndCorporationId(@Param("id") Long id, @Param("corporationId") Long corporationId);
 }

--- a/src/main/java/com/univercloud/hydro/service/DischargeService.java
+++ b/src/main/java/com/univercloud/hydro/service/DischargeService.java
@@ -52,26 +52,11 @@ public interface DischargeService {
     List<DischargeDto> getDischargesByDischargeUser(Long dischargeUserId);
     
     /**
-     * Obtiene descargas por año.
-     * @param year el año
-     * @return lista de descargas del año
-     */
-    List<Discharge> getDischargesByYear(Integer year);
-    
-    /**
-     * Busca una descarga por número y año.
-     * @param number el número de descarga
-     * @param year el año
-     * @return la descarga si existe
-     */
-    Optional<Discharge> getDischargeByNumberAndYear(Integer number, Integer year);
-    
-    /**
      * Busca descargas por nombre (búsqueda parcial).
      * @param name el nombre o parte del nombre a buscar
-     * @return lista de descargas que coinciden
+     * @return lista de descargas que coinciden como DTOs
      */
-    List<Discharge> searchDischargesByName(String name);
+    List<DischargeDto> searchDischargesByName(String name);
     
     /**
      * Elimina una descarga.

--- a/src/main/java/com/univercloud/hydro/service/impl/DischargeServiceImpl.java
+++ b/src/main/java/com/univercloud/hydro/service/impl/DischargeServiceImpl.java
@@ -468,13 +468,31 @@ public class DischargeServiceImpl implements DischargeService {
             throw new IllegalStateException("User does not belong to a corporation");
         }
         
-        return dischargeRepository.findByCorporationAndYear(corporation, year);
+        List<Discharge> discharges = dischargeRepository.findByCorporationAndYear(corporation, year);
+        
+        // Inicializar dischargeMonitorings manualmente para evitar LazyInitializationException
+        // dischargeParameters ya se carga en el EntityGraph
+        for (Discharge discharge : discharges) {
+            Hibernate.initialize(discharge.getDischargeMonitorings());
+        }
+        
+        return discharges;
     }
     
     @Override
     @Transactional(readOnly = true)
     public Optional<Discharge> getDischargeByNumberAndYear(Integer number, Integer year) {
-        return dischargeRepository.findByNumberAndYear(number, year);
+        Optional<Discharge> dischargeOpt = dischargeRepository.findByNumberAndYear(number, year);
+        
+        // Inicializar dischargeMonitorings manualmente para evitar LazyInitializationException
+        // dischargeParameters ya se carga en el EntityGraph
+        if (dischargeOpt.isPresent()) {
+            Discharge discharge = dischargeOpt.get();
+            // Forzar la inicialización de dischargeMonitorings dentro de la transacción
+            Hibernate.initialize(discharge.getDischargeMonitorings());
+        }
+        
+        return dischargeOpt;
     }
     
     @Override
@@ -490,7 +508,15 @@ public class DischargeServiceImpl implements DischargeService {
             throw new IllegalStateException("User does not belong to a corporation");
         }
         
-        return dischargeRepository.findByCorporationAndNameContainingIgnoreCase(corporation, name);
+        List<Discharge> discharges = dischargeRepository.findByCorporationAndNameContainingIgnoreCase(corporation, name);
+        
+        // Inicializar dischargeMonitorings manualmente para evitar LazyInitializationException
+        // dischargeParameters ya se carga en el EntityGraph
+        for (Discharge discharge : discharges) {
+            Hibernate.initialize(discharge.getDischargeMonitorings());
+        }
+        
+        return discharges;
     }
     
     @Override

--- a/src/test/java/com/univercloud/hydro/service/impl/DischargeServiceImplTest.java
+++ b/src/test/java/com/univercloud/hydro/service/impl/DischargeServiceImplTest.java
@@ -281,24 +281,6 @@ class DischargeServiceImplTest {
             dischargeService.getDischargesByDischargeUser(dischargeUserId);
         });
     }
-        
-    @Test
-    void getDischargesByYear_ShouldReturnListOfDischarges_WhenUserAuthenticated() {
-        // Given
-        Integer year = 2024;
-        List<Discharge> expectedDischarges = Arrays.asList(testDischarge);
-        
-        when(authorizationUtils.getCurrentUser()).thenReturn(testUser);
-        when(dischargeRepository.findByCorporationAndYear(testCorporation, year)).thenReturn(expectedDischarges);
-        
-        // When
-        List<Discharge> result = dischargeService.getDischargesByYear(year);
-        
-        // Then
-        assertNotNull(result);
-        assertEquals(1, result.size());
-        assertEquals(testDischarge.getId(), result.get(0).getId());
-    }
     
     @Test
     void deleteDischarge_ShouldReturnTrue_WhenDischargeExistsAndBelongsToUserCorporation() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes JPA fetch graphs and manually initializes lazy collections to avoid `MultipleBagFetchException`, which can subtly affect query performance and serialization behavior. Also removes/changes API/service contracts (DTO vs entity, removed endpoints), which may break existing clients if still in use.
> 
> **Overview**
> Removes the discharge year and number/year lookup endpoints and their corresponding service/repository methods, narrowing the public API surface.
> 
> Standardizes the discharge name search flow to return `DischargeDto` (controller + service) instead of entities.
> 
> Adjusts JPA `@EntityGraph` usage to avoid `MultipleBagFetchException` by no longer eagerly fetching `dischargeMonitorings` in some queries, and instead manually initializes `dischargeMonitorings` in `getDischargeById` via `Hibernate.initialize`. Tests were updated by dropping the removed year-based test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af2bb896c2d25dd8b0651a181ceb25eb5028680a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->